### PR TITLE
Fixed echo interaction regressions

### DIFF
--- a/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
@@ -169,6 +169,7 @@ local function UpdateEchoInteractions(inEchoes, curTimeSpeed, dt)
 	local activeZOffset = 24 + breathLayer
 	local readZOffset = 20
 	local gabenMode = GetConVar("echoes_gabenmode"):GetBool()
+	local profanity = GetConVar("echoes_profanity"):GetBool()
 
 	for _, echo in ipairs(inEchoes) do
 		echo.z_offset = echo.z_offset or 0

--- a/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
@@ -168,12 +168,12 @@ local function UpdateEchoInteractions(inEchoes, curTimeSpeed, dt)
 	local breathLayer = math.sin(curTimeSpeed) * 0.5
 	local activeZOffset = 24 + breathLayer
 	local readZOffset = 20
-
 	local gabenMode = GetConVar("echoes_gabenmode"):GetBool()
 
 	for _, echo in ipairs(inEchoes) do
 		echo.z_offset = echo.z_offset or 0
 		local read = echo.read and !disableReadSys
+		local bOwner = echo.isOwner
 
 		if (((echo.explicit and profanity) or !echo.explicit) and !echo.loading) then
 			if (echo.distSqr < activationDist) then
@@ -281,6 +281,7 @@ hook.Add("PreDrawEffects", "echoes_render_PreDrawEffects", function(bDrawingDept
 		local echoDistSqr = echo.distSqr
 		local read = echo.read and !disableReadSys
 		local bOwner = echo.isOwner
+		if read and bOwner then read = false end
 
 		-- Update initialization factor based on explicit flag and profanity setting
 		if (read and !showRead) then

--- a/gamemodes/echoesbeyond/gamemode/modules/interface/cl_changelog.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/interface/cl_changelog.lua
@@ -2,7 +2,7 @@
 -- A simple changelog menu
 local PANEL = {}
 local vignette = Material("echoesbeyond/vignette.png")
-local changelogID = "rendering"
+local changelogID = "kazfix"
 
 function PANEL:Init()
 	if (IsValid(changeLog)) then
@@ -53,8 +53,8 @@ function PANEL:Init()
 	end
 
 	changelog:SetText([[
-		- Improved Echo rendering performance (Thanks Zak!)
-		- Improved Echo validation system (Thanks Zak!) 
+		- Fixed own Echoes being marked as read (Thanks Kaz!)
+		- Fixed offensive Echoes being unreadable (Thanks Kaz!)
 	]])
 
 	local close = vgui.Create("DButton", self)

--- a/gamemodes/echoesbeyond/gamemode/modules/interface/cl_creditsmenu.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/interface/cl_creditsmenu.lua
@@ -55,7 +55,7 @@ function PANEL:Init()
 	AddCredit("Kevin MacLeod", "Party Song")
 	AddCredit("Aspect™", "Clientside Development")
 	AddCredit("Pancakes", "Serverside Development")
-	AddCredit("Zak", "Performance Improvements")
+	AddCredit("Kaz", "Performance Improvements")
 	AddCredit("Friends", "Feedback, ideas, support, and testing")
 	AddCredit("Bad Actors", "Valuable web security experience")
 


### PR DESCRIPTION
Forgot to re-home some local variables when refactoring the interaction code.

Player-owned echoes will no longer be marked as 'read'.
Also added a condition that if the echo is owned by the player and has been marked 'read' in the last update; the 'read' flag is forced to false.