### PR TITLE
Fixed echo interpolation after partymode ends

### DIFF
--- a/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
@@ -317,6 +317,7 @@ hook.Add("PreDrawEffects", "echoes_render_PreDrawEffects", function(bDrawingDept
 			__vadd(echo.drawPos, echo.partyOffsetLerp)
 			lastPartyModeTime = curTime
 		elseif lastPartyModeTime ~= 0 and curTime - lastPartyModeTime < 10 then -- for about 10 seconds after partymode, lerp party offset back to 0
+			echo.partyOffsetLerp = echo.partyOffsetLerp or Vector()
 			__vmul(echo.partyOffsetLerp, math.max(1 - frameTime * 3, 0))
 			__vadd(echo.drawPos, echo.partyOffsetLerp)
 		end

--- a/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
@@ -255,6 +255,8 @@ hook.Add("PreDrawEffects", "echoes_render_PreDrawEffects", function(bDrawingDept
 
 	echoToGroundFrac = Lerp(frameTime * 2, echoToGroundFrac, enableAir and 0 or 1)
 
+	surface.SetFont("TargetID") -- Set the font for text size calculations
+
 	-- Compute squared distance to all echoes
 	ComputeSqrEchoDist(clientPos)
 
@@ -267,8 +269,6 @@ hook.Add("PreDrawEffects", "echoes_render_PreDrawEffects", function(bDrawingDept
 
 	UpdateEchoRotations(sortedEchoes, frameTime)
 	UpdateEchoTextCache(sortedEchoes)
-
-	surface.SetFont("TargetID") -- Set the font for text size calculations
 
 	render.PushFilterMag(TEXFILTER.ANISOTROPIC)
 	render.PushFilterMin(TEXFILTER.ANISOTROPIC)

--- a/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/echoes/cl_render.lua
@@ -3,6 +3,7 @@ local __vtab = FindMetaTable("Vector")
 local __vunpack = __vtab.Unpack
 local __vset = __vtab.Set
 local __vadd = __vtab.Add
+local __vmul = __vtab.Mul
 local __vsetunpacked = __vtab.SetUnpacked
 
 local __mtab = FindMetaTable("VMatrix")
@@ -227,6 +228,8 @@ local function ComputeEchoMtx(mtx, pos, rot, size, z_offset)
     0,0,0,1)
 end
 
+local lastPartyModeTime = 0
+
 hook.Add("PreDrawEffects", "echoes_render_PreDrawEffects", function(bDrawingDepth, bDrawingSkybox)
 	if (bDrawingDepth or bDrawingSkybox) then return end
 
@@ -311,6 +314,10 @@ hook.Add("PreDrawEffects", "echoes_render_PreDrawEffects", function(bDrawingDept
 		if (partyMode) then
 			echo.partyOffsetLerp = echo.partyOffsetLerp or Vector()
 			echo.partyOffsetLerp = LerpVector(frameTime * 3, echo.partyOffsetLerp, (echo.partyOffset or Vector(0, 0, 0)))
+			__vadd(echo.drawPos, echo.partyOffsetLerp)
+			lastPartyModeTime = curTime
+		elseif lastPartyModeTime ~= 0 and curTime - lastPartyModeTime < 10 then -- for about 10 seconds after partymode, lerp party offset back to 0
+			__vmul(echo.partyOffsetLerp, math.max(1 - frameTime * 3, 0))
 			__vadd(echo.drawPos, echo.partyOffsetLerp)
 		end
 

--- a/gamemodes/echoesbeyond/gamemode/modules/interface/cl_changelog.lua
+++ b/gamemodes/echoesbeyond/gamemode/modules/interface/cl_changelog.lua
@@ -2,7 +2,7 @@
 -- A simple changelog menu
 local PANEL = {}
 local vignette = Material("echoesbeyond/vignette.png")
-local changelogID = "kazfix"
+local changelogID = "kazfix2"
 
 function PANEL:Init()
 	if (IsValid(changeLog)) then
@@ -53,8 +53,8 @@ function PANEL:Init()
 	end
 
 	changelog:SetText([[
-		- Fixed own Echoes being marked as read (Thanks Kaz!)
-		- Fixed offensive Echoes being unreadable (Thanks Kaz!)
+		- Fixed party mode end sequence (Thanks Kaz!)
+		- Made word wrapping more accurate (Thanks Kaz!)
 	]])
 
 	local close = vgui.Create("DButton", self)


### PR DESCRIPTION
When party mode ends, each echo's "partyOffsetLerp" value is now properly interpolated toward 0,0,0 over a period of 10 seconds.

Also a friend of mine (Muffin) found a bug where the word wrapping was incorrect after the rendering update. I believe this regression was caused by my failing to set the font soon enough for text layout caching, this too has been fixed.